### PR TITLE
Calculate encoder scroll faster

### DIFF
--- a/mouse/Src/main.c
+++ b/mouse/Src/main.c
@@ -296,14 +296,10 @@ int main(void) {
 		if (whl_count == 0) {
 			const int whl_now = whl_read();
 			if (whl_now != whl_last) {
-				if (!((whl_now == 0 && whl_last == 3) || (whl_now == 3 && whl_last == 0))) {
-					if (whl_now == 0 && whl_lastlast == 3) {
-						new.whl = (whl_last == 1) ? -1 : (whl_last == 2) ? 1 : 0;
-					} else if (whl_now == 3 && whl_lastlast == 0) {
-						new.whl = (whl_last == 1) ? 1 : (whl_last == 2) ? -1 : 0;
-					}
-					whl_lastlast = whl_last;
-					whl_last = whl_now;
+				if (!((!(whl_now == 0 && whl_lastlast == 3) && !(whl_now == 3 && whl_lastlast == 0)) || (whl_last == 0 || whl_last == 3))) {
+					new.whl = now ^ last;
+				    new.whl |= 0b11111101;
+				    new.whl += 2;
 				}
 			}
 		}

--- a/mouse/Src/main.c
+++ b/mouse/Src/main.c
@@ -298,8 +298,8 @@ int main(void) {
 			if (whl_now != whl_last) {
 				if (!((!(whl_now == 0 && whl_lastlast == 3) && !(whl_now == 3 && whl_lastlast == 0)) || (whl_last == 0 || whl_last == 3))) {
 					new.whl = now ^ last;
-				    new.whl |= 0b11111101;
-				    new.whl += 2;
+					new.whl |= 0b11111101;
+					new.whl += 2;
 				}
 			}
 		}


### PR DESCRIPTION
This does a faster encoder calculation without branching and mostly bit manipulation.

Expects `whl_lastlast`, `whl_last`, `whl_now` to only allow the input range of `0 - 3` 

This has **NOT** been testing with a real m2k/m3k.
But is tested to be correct.

Old Code
https://godbolt.org/z/4shKeKfof

The new code
https://godbolt.org/z/7849sncKs

It is just under 1/3rd the amount of instructions.

Lots of hours spent staring at an excel spreadsheet.

Code below is tested in C.

`gcc test.c -o test -Wall -Werror` to compile

```c
#include <stdint.h>
#include <stdio.h>
#include <stdbool.h>

int8_t m2k(uint8_t whl_lastlast, uint8_t whl_last, uint8_t whl_now)
{
    int8_t dir = 0;
    if (!((whl_now == 0 && whl_last == 3) || (whl_now == 3 && whl_last == 0)))
    {
        if (whl_now == 0 && whl_lastlast == 3)
        {
            dir = (whl_last == 1) ? -1 : (whl_last == 2) ? 1
                                                         : 0;
        }
        else if (whl_now == 3 && whl_lastlast == 0)
        {
            dir = (whl_last == 1) ? 1 : (whl_last == 2) ? -1
                                                        : 0;
        }
    }

    return dir;
}

int8_t decode_quadrature_step(uint8_t lastlast, uint8_t last, uint8_t now, bool print)
{
    // checks if LL and now are exclusively 0 and 3 (both ways)
    int8_t newLL = lastlast - 1;
    int8_t nNow = now - 1;
    uint8_t test = newLL ^ nNow; // will always equal 0xFD

    // checks if the last value is 1 or 2
    uint8_t newLast = last - 1;
    uint8_t lastCheck = ((~newLast) & 0x02) >> 1;
    
    // combine both previous 2 checks
    uint8_t finalCheck = ~test | lastCheck;
    
    if (finalCheck == 0x03)
    {
        // calculate the direction
        uint8_t now_xor_last = now ^ last;
        now_xor_last |= 0b11111101;
        now_xor_last += 2;
        return (int8_t)now_xor_last;
    }
    return 0;
}

// main
int main()
{
    int totalMismatches = 0;
    int mismatches = 0;
    // loop through both and compare the results
    for (uint8_t i = 0; i < 4; i++)
    {
        for (uint8_t j = 0; j < 4; j++)
        {
            for (uint8_t k = 0; k < 4; k++)
            {
                totalMismatches++;
                int8_t result1 = m2k(i, j, k);
                int8_t result2 = decode_quadrature_step(i, j, k, true);
                if (result1 != result2)
                {
                    mismatches++;
                    printf("Mismatch found for ll: %d, last: %d, now: %d, result1: %02hhx, result2: %02hhx \n", i, j, k, result1, result2);
                }
            }
        }
    }

    if (mismatches == 0)
    {
        printf("All tests passed!\n");
    }
    else
    {
        printf("Total mismatches: %d of %d\n", mismatches, totalMismatches);
    }

    return 0;
}```